### PR TITLE
Fix for issue #5  JSON Unmarshalling error

### DIFF
--- a/static/js/models/auth.js
+++ b/static/js/models/auth.js
@@ -36,8 +36,8 @@ window.AuthUser = Backbone.Model.extend({
         id: null,
         name: "",
         assistant: "",
-        disabled: '0',
-        is_manager: '0',
+        disabled: false,
+        is_manager: false,
         mixers: {},
         assistant_for: {}
     }

--- a/static/js/models/person.js
+++ b/static/js/models/person.js
@@ -43,8 +43,8 @@ window.Person = Backbone.Model.extend({
         id: null,
         name: "",
         assistant: "",
-        disabled: '0',
-        is_manager: '0',
+        disabled: false,
+        is_manager: false,
         mixers: {},
         assistant_for: {}
     }


### PR DESCRIPTION
Sets defaults to boolean values rather than strings.  Gets rid of the "json: cannot unmarshal string into Go value of type bool" message when a new user signs up.